### PR TITLE
ci: build gate on PR (catch build failures before merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,24 @@ jobs:
         path: playwright-report/
         retention-days: 7
 
+  build-check:
+    name: "✈️ Pre-flight Build Check (PR only)"
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    if: github.event_name == 'pull_request'   # main 上 deploy job 已含 build，不重複
+    steps:
+    - name: "🔄 Flight Plan: Checkout Code"
+      uses: actions/checkout@v6
+    - name: "🔧 Ground Crew: Setup Node.js Environment"
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - name: "⛽ Refueling: Install Dependencies"
+      run: npm ci
+    - name: "🚀 Build Aircraft Systems (verify compile before merge)"
+      run: npm run build
+
   deploy:
     name: "🛬 Landing & Deployment"
     runs-on: ubuntu-latest


### PR DESCRIPTION
`npm run build` 目前只在 main 的 deploy job 跑 → 弄壞 build 的 PR 測綠 merge 後才爆(像 vite-plugin-pwa peer 衝突那種)。加 `build-check` job(PR only,main 不重複 build)→ PR 就驗 build 能編譯。自動部署不變。

🤖 Generated with [Claude Code](https://claude.com/claude-code)