### PR TITLE
ci: serialize Pages deploy (fix deployment_queued timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
 
   deploy:
     name: "🛬 Landing & Deployment"
+    # Pages 一次只能一個部署 → 序列化避免 deployment_queued timeout + 重複 artifact 撞名
+    # （job-level，不擋 PR 測試 job）。cancel-in-progress=false：不砍進行中的部署。
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     needs: [unit-tests]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
老鷹分診:deploy-pages 冷啟 timeout + 重跑失敗 job 撞 duplicate artifact。加 job-level concurrency(不擋 PR 測試)。