### PR TITLE
ci: grant PR-comment permission (fix 403) + retry flaky playwright install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,26 +54,35 @@ jobs:
         node-version: '22'
         cache: 'npm'
 
-    - name: "🛫 Boarding Playwright Browsers"
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-browsers-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-browsers-
-
     - name: "⛽ Refueling: Install Dependencies"
       run: npm ci
 
+    - name: "🔎 Get Playwright version"
+      id: pw-version
+      run: echo "VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+    - name: "🛫 Boarding Playwright Browsers"
+      id: cache-playwright
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.VERSION }}
+
     - name: "🛫 Deploying Browser Engines"
-      # Retry: `--with-deps` runs apt, which intermittently fails on the runner's
-      # microsoft-packages mirror ("Failed to fetch ... does the network require authentication?").
-      run: |
-        for i in 1 2 3; do
-          npx playwright install --with-deps && exit 0
-          echo "::warning::playwright install failed (attempt $i/3), retrying in 15s…"; sleep 15
-        done
-        exit 1
+      # Cache hit → install only system deps (skip the hundreds-MB browser download → CI flies).
+      # nick-fields/retry (actively maintained; microsoft/playwright-actions is archived) rides
+      # out the flaky microsoft-packages apt mirror — no hand-rolled shell loop.
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: |
+          if [ "${{ steps.cache-playwright.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps
+          else
+            npx playwright install --with-deps
+          fi
 
     - name: "✈️ Execute Local E2E Flight Plan"
       run: npm run test:e2e:local
@@ -175,26 +184,35 @@ jobs:
         node-version: '22'
         cache: 'npm'
 
-    - name: "🛫 Boarding Playwright Browsers"
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-browsers-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-browsers-
-
     - name: "⛽ Refueling: Install Dependencies"
       run: npm ci
 
+    - name: "🔎 Get Playwright version"
+      id: pw-version
+      run: echo "VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+    - name: "🛫 Boarding Playwright Browsers"
+      id: cache-playwright
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.VERSION }}
+
     - name: "🛫 Deploying Browser Engines"
-      # Retry: `--with-deps` runs apt, which intermittently fails on the runner's
-      # microsoft-packages mirror ("Failed to fetch ... does the network require authentication?").
-      run: |
-        for i in 1 2 3; do
-          npx playwright install --with-deps && exit 0
-          echo "::warning::playwright install failed (attempt $i/3), retrying in 15s…"; sleep 15
-        done
-        exit 1
+      # Cache hit → install only system deps (skip the hundreds-MB browser download → CI flies).
+      # nick-fields/retry (actively maintained; microsoft/playwright-actions is archived) rides
+      # out the flaky microsoft-packages apt mirror — no hand-rolled shell loop.
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: |
+          if [ "${{ steps.cache-playwright.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps
+          else
+            npx playwright install --with-deps
+          fi
 
     - name: "🛫 Holding Pattern: Waiting for Deployment"
       if: github.event_name == 'push'   # only a fresh deploy needs propagation time; PR runs test the live site as-is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: "🛫 Boarding Playwright Browsers"
       id: cache-playwright
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.VERSION }}
@@ -193,7 +193,7 @@ jobs:
 
     - name: "🛫 Boarding Playwright Browsers"
       id: cache-playwright
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,14 @@ jobs:
       run: npm ci
 
     - name: "🛫 Deploying Browser Engines"
-      run: npx playwright install --with-deps
+      # Retry: `--with-deps` runs apt, which intermittently fails on the runner's
+      # microsoft-packages mirror ("Failed to fetch ... does the network require authentication?").
+      run: |
+        for i in 1 2 3; do
+          npx playwright install --with-deps && exit 0
+          echo "::warning::playwright install failed (attempt $i/3), retrying in 15s…"; sleep 15
+        done
+        exit 1
 
     - name: "✈️ Execute Local E2E Flight Plan"
       run: npm run test:e2e:local
@@ -155,6 +162,9 @@ jobs:
     # `deploy` dep is skipped on PRs. Caveat: a PR run tests the *current* deployment, so
     # it verifies test-harness changes; app-code regressions are gated by e2e-tests-local.
     if: ${{ !cancelled() && (github.event_name == 'pull_request' || (github.ref == 'refs/heads/main' && github.event_name == 'push')) }}
+    permissions:
+      contents: read           # checkout
+      pull-requests: write     # "Comment PR with Test Results" (github-script) posts to the PR — fixes the "Resource not accessible by integration" 403 (default token is read-only)
     steps:
     - name: "🔄 Flight Plan: Checkout Code"
       uses: actions/checkout@v6
@@ -177,7 +187,14 @@ jobs:
       run: npm ci
 
     - name: "🛫 Deploying Browser Engines"
-      run: npx playwright install --with-deps
+      # Retry: `--with-deps` runs apt, which intermittently fails on the runner's
+      # microsoft-packages mirror ("Failed to fetch ... does the network require authentication?").
+      run: |
+        for i in 1 2 3; do
+          npx playwright install --with-deps && exit 0
+          echo "::warning::playwright install failed (attempt $i/3), retrying in 15s…"; sleep 15
+        done
+        exit 1
 
     - name: "🛫 Holding Pattern: Waiting for Deployment"
       if: github.event_name == 'push'   # only a fresh deploy needs propagation time; PR runs test the live site as-is


### PR DESCRIPTION
Follow-up to #14 — two CI-robustness fixes the #14 work surfaced.

## 1. Comment step 403
`📝 Comment PR with Test Results` (github-script) hit `Resource not accessible by integration` — the default workflow token is read-only, so it can't post to the PR. Grant the `e2e-tests-production` job `pull-requests: write`. (Step stays `continue-on-error` as belt-and-suspenders — reporting must not gate the build.)

## 2. Flaky `playwright install --with-deps`
`--with-deps` runs apt, which intermittently fails on the runner's microsoft-packages mirror (`Failed to fetch https://packages.microsoft.com/... exit 1`), randomly reddening runs — e.g. the post-#14-merge run on main (28897547558) failed here, while e2e-local passed. Wrap **both** install steps (local + production) in a 3× retry with 15s backoff.

ci.yml-only; no test changes. cc @jonatw-eagle